### PR TITLE
Revamp catalog layout with filters and comparisons

### DIFF
--- a/frontend/components/catalog/ModelComparisonTable.tsx
+++ b/frontend/components/catalog/ModelComparisonTable.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+
+import { Badge } from "../ui/Badge";
+import { Button } from "../ui/Button";
+import { Card } from "../ui/Card";
+import { CatalogModel, formatReleaseDate, normalizeStringArray } from "./ModelList";
+import { PriceDisplay } from "./PriceDisplay";
+
+interface ModelComparisonTableProps {
+  models: CatalogModel[];
+  onRemoveModel?: (modelId: number) => void;
+  onClear?: () => void;
+}
+
+export function ModelComparisonTable({ models, onRemoveModel, onClear }: ModelComparisonTableProps) {
+  return (
+    <Card
+      title="Model comparison"
+      description="Evaluate models side by side to find the best fit."
+      actions={
+        onClear && (
+          <Button variant="secondary" size="sm" onClick={onClear}>
+            Clear selection
+          </Button>
+        )
+      }
+    >
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+          <thead className="bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
+            <tr>
+              <th scope="col" className="px-4 py-3">
+                Feature
+              </th>
+              {models.map((model) => (
+                <th key={model.id} scope="col" className="min-w-[220px] px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <Link
+                        href={`/catalog/${model.id}`}
+                        className="text-sm font-semibold text-slate-700 transition-colors hover:text-primary dark:text-slate-100"
+                      >
+                        {model.model}
+                      </Link>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{model.vendor.name}</div>
+                    </div>
+                    {onRemoveModel && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onRemoveModel(model.id)}
+                        aria-label={`Remove ${model.model} from comparison`}
+                        className="px-2 py-1 text-base leading-none"
+                      >
+                        ×
+                      </Button>
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-300">
+            <tr>
+              <th scope="row" className="whitespace-nowrap px-4 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Pricing
+              </th>
+              {models.map((model) => (
+                <td key={model.id} className="px-4 py-4 align-top">
+                  <PriceDisplay
+                    price={{
+                      price_model: model.priceModel,
+                      price_currency: model.priceCurrency,
+                      price_data: model.priceData
+                    }}
+                    variant="compact"
+                  />
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row" className="whitespace-nowrap px-4 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Capabilities
+              </th>
+              {models.map((model) => {
+                const capabilities = normalizeStringArray(model.modelCapability);
+                return (
+                  <td key={model.id} className="px-4 py-4 align-top">
+                    {capabilities.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {capabilities.map((capability) => (
+                          <Badge key={capability} color="secondary">
+                            {capability}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-slate-500">No data</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+            <tr>
+              <th scope="row" className="whitespace-nowrap px-4 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Licenses
+              </th>
+              {models.map((model) => {
+                const licenses = normalizeStringArray(model.license);
+                return (
+                  <td key={model.id} className="px-4 py-4 align-top">
+                    {licenses.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {licenses.map((license) => (
+                          <Badge key={license} color="success">
+                            {license}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-slate-500">—</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+            <tr>
+              <th scope="row" className="whitespace-nowrap px-4 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Release
+              </th>
+              {models.map((model) => (
+                <td key={model.id} className="px-4 py-4 align-top">
+                  {formatReleaseDate(model.release_date) ? (
+                    <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                      {formatReleaseDate(model.release_date)}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-slate-400 dark:text-slate-500">Pending</span>
+                  )}
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <th scope="row" className="whitespace-nowrap px-4 py-4 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Highlights
+              </th>
+              {models.map((model) => (
+                <td key={model.id} className="px-4 py-4 align-top">
+                  {model.description ? (
+                    <p className="text-sm text-slate-600 dark:text-slate-300">{model.description}</p>
+                  ) : (
+                    <span className="text-xs text-slate-400 dark:text-slate-500">—</span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/components/catalog/ModelList.tsx
+++ b/frontend/components/catalog/ModelList.tsx
@@ -19,9 +19,11 @@ export interface CatalogModel {
 
 interface ModelListProps {
   models: CatalogModel[];
+  selectedModelIds?: number[];
+  onToggleCompare?: (modelId: number) => void;
 }
 
-const normalizeStringArray = (value: unknown): string[] => {
+export const normalizeStringArray = (value: unknown): string[] => {
   const expand = (input: unknown): string[] => {
     if (!input) return [];
     if (Array.isArray(input)) {
@@ -54,83 +56,154 @@ const normalizeStringArray = (value: unknown): string[] => {
 };
 
 
-const formatReleaseDate = (value?: string | null) => {
+export const formatReleaseDate = (value?: string | null) => {
   if (!value) return null;
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return new Intl.DateTimeFormat("en", { year: "numeric", month: "short" }).format(date);
 };
 
-export function ModelList({ models }: ModelListProps) {
+export function ModelList({ models, selectedModelIds = [], onToggleCompare }: ModelListProps) {
   if (!models.length) {
     return <Card title="No models found">Try adjusting your filters or search query.</Card>;
   }
 
   return (
-    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-      {models.map((model) => {
-        const capabilities = normalizeStringArray(model.modelCapability);
-        const licenses = normalizeStringArray(model.license);
-        const releaseDate = formatReleaseDate(model.release_date);
+    <Card className="p-0">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+          <thead className="bg-slate-50/80 dark:bg-slate-900/50">
+            <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <th scope="col" className="px-4 py-3">
+                Compare
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Model details
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Pricing snapshot
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Capabilities
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Licenses
+              </th>
+              <th scope="col" className="px-4 py-3">
+                Release
+              </th>
+              <th scope="col" className="px-4 py-3 text-right">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-300">
+            {models.map((model) => {
+              const capabilities = normalizeStringArray(model.modelCapability);
+              const licenses = normalizeStringArray(model.license);
+              const releaseDate = formatReleaseDate(model.release_date);
+              const isSelected = selectedModelIds.includes(model.id);
 
-        
-        return (
-          <Card
-            key={model.id}
-            title={
-              <Link
-                href={`/catalog/${model.id}`}
-                className="text-inherit transition-colors hover:text-primary hover:underline"
-              >
-                {model.model}
-              </Link>
-            }
-            description={model.description}
-            actions={<Badge color="primary">{model.vendor.name}</Badge>}
-          >
-            <div className="mt-4 flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300">
-              <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                <span>Pricing</span>
-                <PriceDisplay
-                  price={{
-                    price_model: model.priceModel,
-                    price_currency: model.priceCurrency,
-                    price_data: model.priceData
-                  }}
-                  variant="compact"
-                />
-              </div>
-              {releaseDate && (
-                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  <span>Released</span>
-                  <span>{releaseDate}</span>
-                </div>
-              )}
-              {capabilities.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {capabilities.map((capability) => (
-                    <Badge key={capability} color="secondary">
-                      {capability}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-              {licenses.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {licenses.map((license) => (
-                    <Badge key={license} color="success">
-                      {license}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-              <Link href={`/catalog/${model.id}`} className="text-sm text-primary hover:text-primary-dark">
-                View details →
-              </Link>
-            </div>
-          </Card>
-        );
-      })}
-    </div>
+              return (
+                <tr
+                  key={model.id}
+                  className="transition hover:bg-slate-50/80 dark:hover:bg-slate-900/40"
+                >
+                  <td className="px-4 py-4 align-top">
+                    <label className="flex items-center gap-2 text-xs font-medium">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                        checked={isSelected}
+                        onChange={() => onToggleCompare?.(model.id)}
+                        aria-label={`Select ${model.model} for comparison`}
+                      />
+                      <span className="hidden text-slate-500 sm:inline">Compare</span>
+                    </label>
+                  </td>
+                  <td className="max-w-xs px-4 py-4 align-top">
+                    <div className="flex flex-col gap-2">
+                      <div>
+                        <Link
+                          href={`/catalog/${model.id}`}
+                          className="text-base font-semibold text-slate-800 transition-colors hover:text-primary dark:text-slate-100"
+                        >
+                          {model.model}
+                        </Link>
+                        <div className="mt-1 flex flex-wrap gap-2">
+                          <Badge color="primary">{model.vendor.name}</Badge>
+                          {model.priceModel && (
+                            <Badge color="secondary">{model.priceModel}</Badge>
+                          )}
+                        </div>
+                      </div>
+                      {model.description && (
+                        <p className="line-clamp-2 text-sm text-slate-500 dark:text-slate-400">{model.description}</p>
+                      )}
+                    </div>
+                  </td>
+                  <td className="w-64 px-4 py-4 align-top text-left">
+                    <PriceDisplay
+                      price={{
+                        price_model: model.priceModel,
+                        price_currency: model.priceCurrency,
+                        price_data: model.priceData
+                      }}
+                      variant="compact"
+                    />
+                  </td>
+                  <td className="px-4 py-4 align-top">
+                    {capabilities.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {capabilities.slice(0, 3).map((capability) => (
+                          <Badge key={capability} color="secondary">
+                            {capability}
+                          </Badge>
+                        ))}
+                        {capabilities.length > 3 && (
+                          <span className="text-xs text-slate-400 dark:text-slate-500">
+                            +{capabilities.length - 3} more
+                          </span>
+                        )}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-slate-500">No data</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-4 align-top">
+                    {licenses.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {licenses.map((license) => (
+                          <Badge key={license} color="success">
+                            {license}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-slate-500">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-4 align-top">
+                    {releaseDate ? (
+                      <span className="text-sm font-medium text-slate-600 dark:text-slate-300">{releaseDate}</span>
+                    ) : (
+                      <span className="text-xs text-slate-400 dark:text-slate-500">Pending</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-4 align-top text-right">
+                    <Link
+                      href={`/catalog/${model.id}`}
+                      className="text-sm font-medium text-primary hover:text-primary-dark"
+                    >
+                      View details →
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </Card>
   );
 }

--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -1,9 +1,17 @@
+import { ThemeToggle } from "./ThemeToggle";
+
 export function Footer() {
   return (
     <footer className="border-t border-slate-200 bg-white/80 dark:border-slate-800 dark:bg-slate-950/70">
-      <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-2 px-6 py-6 text-sm text-slate-500 transition dark:text-slate-400 sm:flex-row">
-        <span>© {new Date().getFullYear()} Model Price Hub.</span>
-        <span>Built for comparing LLM pricing.</span>
+      <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-slate-500 transition dark:text-slate-400 sm:flex-row">
+        <div className="flex flex-col items-center gap-1 text-center sm:items-start sm:text-left">
+          <span>© {new Date().getFullYear()} Model Price Hub.</span>
+          <span>Built for comparing LLM pricing.</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Theme</span>
+          <ThemeToggle />
+        </div>
       </div>
     </footer>
   );

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -4,14 +4,33 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { useAuthStore } from "../../lib/hooks/useAuth";
+import { useFilterPanelStore } from "../../lib/hooks/useFilterPanel";
 import { Button } from "../ui/Button";
-import { ThemeToggle } from "./ThemeToggle";
 
 const navItems: Array<{ href: string; label: string }> = [];
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="11" cy="11" r="7" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}
 
 export function Header() {
   const pathname = usePathname();
   const { isAuthenticated, logout } = useAuthStore();
+  const { toggle, isOpen } = useFilterPanelStore();
 
   const isAdminRoute = pathname?.startsWith("/admin");
 
@@ -39,7 +58,17 @@ export function Header() {
           </nav>
         )}
         <div className="flex items-center gap-2">
-          <ThemeToggle />
+          <Button
+            variant={isOpen ? "primary" : "ghost"}
+            size="sm"
+            onClick={toggle}
+            aria-label="Search and filter models"
+            aria-pressed={isOpen}
+            className="gap-2"
+          >
+            <SearchIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">Filters</span>
+          </Button>
           {isAuthenticated && isAdminRoute && (
             <Button variant="secondary" size="sm" onClick={logout}>
               Logout

--- a/frontend/lib/hooks/useFilterPanel.ts
+++ b/frontend/lib/hooks/useFilterPanel.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { create } from "zustand";
+
+interface FilterPanelState {
+  isOpen: boolean;
+  focusHandler: (() => void) | null;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  registerFocusHandler: (handler: (() => void) | null) => void;
+}
+
+export const useFilterPanelStore = create<FilterPanelState>((set, get) => ({
+  isOpen: false,
+  focusHandler: null,
+  open: () => {
+    set({ isOpen: true });
+    setTimeout(() => {
+      get().focusHandler?.();
+    }, 50);
+  },
+  close: () => set({ isOpen: false }),
+  toggle: () => {
+    set((state) => ({ isOpen: !state.isOpen }));
+    setTimeout(() => {
+      if (get().isOpen) {
+        get().focusHandler?.();
+      }
+    }, 50);
+  },
+  registerFocusHandler: (handler) => set({ focusHandler: handler })
+}));


### PR DESCRIPTION
## Summary
- restyle the catalog list into a responsive table with comparison checkboxes and contextual pricing chips
- add a collapsible filter overlay triggered from the navbar with automatic search focus and reusable state management
- enrich pricing displays, move the theme toggle to the footer, and surface a multi-model comparison table on the catalog page

## Testing
- `npm run lint` *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68deaa3cc004832185be89c608ff4853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Compare multiple models side-by-side; select models from the list and manage selections (remove/clear).
  * Full-screen filter panel with instant search focus; accessible via a new “Filters” button in the header.
  * Theme switcher now available in the footer.

* Style
  * Catalog redesigned as a table with compare checkboxes, clearer details, and streamlined actions.
  * Pricing views revamped: clearer token/tier/per-call layouts, added cached token pricing, and consistent currency/per labels.
  * Filter panel updated with header, description, Reset/Apply actions, and improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->