### PR TITLE
Add currency configuration API and enhance pricing display

### DIFF
--- a/backend/app/api/routers/public.py
+++ b/backend/app/api/routers/public.py
@@ -4,11 +4,13 @@ from ...api.deps import get_db
 from ...repositories.model_repository import ModelRepository
 from ...repositories.vendor_repository import VendorRepository
 from ...schemas.common import PaginatedResponse
+from ...schemas.currency import CurrencyConfig
 from ...schemas.model import ModelRead
 from ...schemas.vendor import VendorRead
 from ...services.model_service import ModelService
 from ...services.search_service import ModelSearchParams, VendorQueryParams
 from ...services.vendor_service import VendorService
+from ...core.config import Settings, get_settings
 
 def get_vendor_service() -> VendorService:
     return VendorService()
@@ -64,3 +66,15 @@ def get_model(
 ):
     model = service.get_model(session, model_id, repository=repo)
     return ModelRead.from_orm(model)
+
+
+@router.get("/currency", response_model=CurrencyConfig)
+def get_currency_config(settings: Settings = Depends(get_settings)) -> CurrencyConfig:
+    exchange_rates = {code.upper(): float(rate) for code, rate in settings.currency_exchange_rates.items()}
+    display_currency = settings.display_currency.upper()
+    available = sorted(exchange_rates.keys())
+    return CurrencyConfig(
+        displayCurrency=display_currency,
+        exchangeRates=exchange_rates,
+        availableCurrencies=available,
+    )

--- a/backend/app/schemas/currency.py
+++ b/backend/app/schemas/currency.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Field
+
+
+class CurrencyConfig(BaseModel):
+    display_currency: str = Field(..., alias="displayCurrency")
+    exchange_rates: dict[str, float] = Field(..., alias="exchangeRates")
+    available_currencies: list[str] = Field(..., alias="availableCurrencies")
+
+    class Config:
+        allow_population_by_field_name = True

--- a/backend/app/tests/test_currency.py
+++ b/backend/app/tests/test_currency.py
@@ -1,0 +1,35 @@
+from app.core.config import get_settings
+
+
+def test_currency_endpoint_returns_defaults(client):
+    response = client.get("/api/public/currency")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["displayCurrency"] == "USD"
+    assert "USD" in data["exchangeRates"]
+    assert "USD" in data["availableCurrencies"]
+
+
+def test_currency_endpoint_uses_settings(client):
+    settings = get_settings()
+    original_display = settings.display_currency
+    original_rates = dict(settings.currency_exchange_rates)
+    try:
+        settings.display_currency = "EUR"
+        settings.currency_exchange_rates = {
+            "USD": 1.0,
+            "EUR": 1.08,
+            "JPY": 0.0072,
+        }
+
+        response = client.get("/api/public/currency")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["displayCurrency"] == "EUR"
+        assert data["exchangeRates"]["EUR"] == settings.currency_exchange_rates["EUR"]
+        assert set(data["availableCurrencies"]) == {"USD", "EUR", "JPY"}
+    finally:
+        settings.display_currency = original_display
+        settings.currency_exchange_rates = original_rates

--- a/frontend/components/currency/CurrencySelector.tsx
+++ b/frontend/components/currency/CurrencySelector.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import classNames from "classnames";
+import { useMemo } from "react";
+
+import { useCurrency } from "../../lib/hooks/useCurrency";
+
+interface CurrencySelectorProps {
+  className?: string;
+  size?: "sm" | "md";
+}
+
+export function CurrencySelector({ className, size = "sm" }: CurrencySelectorProps) {
+  const { availableCurrencies, selectedCurrency, setSelectedCurrency, isLoading } = useCurrency();
+
+  const options = useMemo(() => {
+    return availableCurrencies.map((code) => ({ label: code, value: code }));
+  }, [availableCurrencies]);
+
+  if (!options.length) {
+    return null;
+  }
+
+  return (
+    <label
+      className={classNames(
+        "flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-slate-400",
+        className
+      )}
+    >
+      <span>Currency</span>
+      <select
+        value={selectedCurrency}
+        onChange={(event) => setSelectedCurrency(event.target.value)}
+        disabled={isLoading}
+        className={classNames(
+          "rounded-md border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200",
+          {
+            "px-2 py-1": size === "sm",
+            "px-3 py-2 text-sm": size === "md"
+          }
+        )}
+        aria-label="Select currency"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from "../../lib/hooks/useAuth";
 import { useFilterPanelStore } from "../../lib/hooks/useFilterPanel";
 import { useLayoutModeStore } from "../../lib/hooks/useLayoutMode";
 import { Button } from "../ui/Button";
+import { CurrencySelector } from "../currency/CurrencySelector";
 
 const navItems: Array<{ href: string; label: string }> = [];
 
@@ -67,7 +68,8 @@ export function Header() {
             ))}
           </nav>
         )}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
+          <CurrencySelector />
           {showFilterButton && (
             <Button
               variant={isOpen ? "primary" : "ghost"}

--- a/frontend/lib/hooks/useCurrency.ts
+++ b/frontend/lib/hooks/useCurrency.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import { create } from "zustand";
+import { useQuery } from "@tanstack/react-query";
+
+import { ApiClient } from "../apiClient";
+
+interface CurrencyConfigResponse {
+  displayCurrency: string;
+  exchangeRates: Record<string, number>;
+  availableCurrencies: string[];
+}
+
+interface CurrencyState {
+  selectedCurrency?: string;
+  availableCurrencies: string[];
+  setSelectedCurrency: (currency: string) => void;
+  syncAvailableCurrencies: (currencies: string[], defaultCurrency: string) => void;
+}
+
+const useCurrencyStore = create<CurrencyState>((set) => ({
+  selectedCurrency: undefined,
+  availableCurrencies: [],
+  setSelectedCurrency: (currency) => set({ selectedCurrency: currency?.toUpperCase() ?? undefined }),
+  syncAvailableCurrencies: (currencies, defaultCurrency) =>
+    set((state) => {
+      const normalizedDefault = defaultCurrency.toUpperCase();
+      const normalizedList = Array.from(
+        new Set(
+          currencies
+            .map((code) => code?.toUpperCase())
+            .filter((code): code is string => Boolean(code && code.trim()))
+        )
+      );
+      if (!normalizedList.includes(normalizedDefault)) {
+        normalizedList.push(normalizedDefault);
+      }
+      normalizedList.sort((a, b) => a.localeCompare(b));
+      const nextSelected =
+        state.selectedCurrency && normalizedList.includes(state.selectedCurrency)
+          ? state.selectedCurrency
+          : normalizedDefault;
+      return {
+        availableCurrencies: normalizedList,
+        selectedCurrency: nextSelected
+      };
+    })
+}));
+
+const apiClient = new ApiClient();
+
+export function useCurrency() {
+  const query = useQuery<CurrencyConfigResponse>({
+    queryKey: ["currency-config"],
+    queryFn: async () => apiClient.get<CurrencyConfigResponse>("/api/public/currency"),
+    staleTime: 10 * 60 * 1000
+  });
+
+  const syncAvailableCurrencies = useCurrencyStore((state) => state.syncAvailableCurrencies);
+  const setSelectedCurrency = useCurrencyStore((state) => state.setSelectedCurrency);
+  const availableCurrencies = useCurrencyStore((state) => state.availableCurrencies);
+  const storedSelectedCurrency = useCurrencyStore((state) => state.selectedCurrency);
+
+  const displayCurrency = useMemo(
+    () => query.data?.displayCurrency?.toUpperCase() ?? "USD",
+    [query.data?.displayCurrency]
+  );
+
+  useEffect(() => {
+    if (!query.data) return;
+    const responseCurrencies =
+      query.data.availableCurrencies && query.data.availableCurrencies.length > 0
+        ? query.data.availableCurrencies
+        : Object.keys(query.data.exchangeRates ?? {});
+    syncAvailableCurrencies(responseCurrencies, displayCurrency);
+  }, [query.data, displayCurrency, syncAvailableCurrencies]);
+
+  const normalizedRates = useMemo(() => {
+    const rates: Record<string, number> = { [displayCurrency]: 1 };
+    const responseRates = query.data?.exchangeRates ?? {};
+    Object.entries(responseRates).forEach(([code, rate]) => {
+      const normalizedCode = code.toUpperCase();
+      const numericRate =
+        typeof rate === "number" ? rate : typeof rate === "string" ? Number(rate) : NaN;
+      if (Number.isFinite(numericRate) && numericRate > 0) {
+        rates[normalizedCode] = numericRate;
+      }
+    });
+    return rates;
+  }, [query.data?.exchangeRates, displayCurrency]);
+
+  const selectedCurrency = useMemo(() => {
+    const stored = storedSelectedCurrency?.toUpperCase();
+    if (stored && normalizedRates[stored]) {
+      return stored;
+    }
+    return displayCurrency;
+  }, [displayCurrency, normalizedRates, storedSelectedCurrency]);
+
+  const convertCurrency = useCallback(
+    (value: number | null | undefined, fromCurrency?: string, toCurrency?: string) => {
+      if (value === null || value === undefined) return null;
+      if (!Number.isFinite(value)) return null;
+
+      const source = (fromCurrency ?? displayCurrency).toUpperCase();
+      const target = (toCurrency ?? selectedCurrency).toUpperCase();
+
+      if (source === target) {
+        return { amount: value, currency: target };
+      }
+
+      const fromRate = normalizedRates[source];
+      const toRate = normalizedRates[target];
+
+      if (!fromRate || !toRate) {
+        return { amount: value, currency: source };
+      }
+
+      const amountInUsd = value * fromRate;
+      return { amount: amountInUsd / toRate, currency: target };
+    },
+    [displayCurrency, normalizedRates, selectedCurrency]
+  );
+
+  const formatCurrency = useCallback(
+    (
+      value: number | string | null | undefined,
+      fromCurrency?: string,
+      options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }
+    ) => {
+      if (value === null || value === undefined) return "";
+      const numericValue = typeof value === "string" ? Number(value) : value;
+      if (!Number.isFinite(numericValue)) {
+        return typeof value === "string" ? value : "";
+      }
+
+      const conversion = convertCurrency(numericValue, fromCurrency);
+      const amount = conversion?.amount ?? numericValue;
+      const currency = conversion?.currency ?? (fromCurrency ?? selectedCurrency);
+
+      const minimumFractionDigits =
+        options?.minimumFractionDigits ?? (Math.abs(amount) < 1 ? 4 : 2);
+      const maximumFractionDigits =
+        options?.maximumFractionDigits ?? (Math.abs(amount) < 1 ? 4 : 2);
+
+      try {
+        return new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency,
+          minimumFractionDigits,
+          maximumFractionDigits
+        }).format(amount);
+      } catch (error) {
+        const fallbackDigits = Math.min(maximumFractionDigits, Math.abs(amount) < 1 ? 4 : 2);
+        return `${amount.toFixed(fallbackDigits)} ${currency}`;
+      }
+    },
+    [convertCurrency, selectedCurrency]
+  );
+
+  return {
+    config: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    availableCurrencies,
+    selectedCurrency,
+    setSelectedCurrency: (currency: string) => setSelectedCurrency(currency),
+    convertCurrency,
+    formatCurrency,
+    displayCurrency,
+    exchangeRates: normalizedRates
+  };
+}


### PR DESCRIPTION
## Summary
- extend the backend settings with configurable display currency and exchange-rate parsing and expose a `/api/public/currency` endpoint
- add a shared currency hook and selector on the frontend so prices are converted client-side using the backend-provided configuration
- refresh the tiered pricing UI to support tier selection in the catalog list and show full tier breakdowns in comparisons while applying currency conversions

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68df6791677c83218e197277c849a194