### PR TITLE
Refactor catalog compare workflow

### DIFF
--- a/frontend/app/catalog/compare/page.tsx
+++ b/frontend/app/catalog/compare/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Button } from "../../../components/ui/Button";
+import { ModelComparisonTable } from "../../../components/catalog/ModelComparisonTable";
+import type { CatalogModel } from "../../../components/catalog/ModelList";
+import { useModelsByIds } from "../../../lib/hooks/useModels";
+
+export default function CatalogComparePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const modelsParam = searchParams.get("models") ?? "";
+  const filtersParam = searchParams.get("filters") ?? "";
+
+  const modelIds = useMemo(() => {
+    return modelsParam
+      .split(",")
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => Number.isInteger(value) && value > 0);
+  }, [modelsParam]);
+
+  const { data: models = [], isLoading, isError } = useModelsByIds(modelIds);
+
+  const handleNavigateToCatalog = () => {
+    if (filtersParam) {
+      router.push(`/catalog?${filtersParam}`);
+    } else {
+      router.push("/catalog");
+    }
+  };
+
+  const updateComparedModels = (ids: number[]) => {
+    if (ids.length === 0) {
+      handleNavigateToCatalog();
+      return;
+    }
+    const query = new URLSearchParams();
+    query.set("models", ids.join(","));
+    if (filtersParam) {
+      query.set("filters", filtersParam);
+    }
+    router.replace(`/catalog/compare?${query.toString()}`);
+  };
+
+  const handleRemoveModel = (modelId: number) => {
+    const nextIds = modelIds.filter((id) => id !== modelId);
+    updateComparedModels(nextIds);
+  };
+
+  const handleClear = () => {
+    updateComparedModels([]);
+  };
+
+  const heading = (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex items-center gap-3">
+        <Button type="button" variant="secondary" onClick={handleNavigateToCatalog}>
+          ← Back to catalog
+        </Button>
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800 dark:text-slate-100">Model comparison</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Review pricing, capabilities, and release information side by side.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (modelIds.length === 0) {
+    return (
+      <div className="space-y-6">
+        {heading}
+        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+          No models selected for comparison. Return to the catalog to choose models.
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        {heading}
+        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+          Loading comparison data...
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-6">
+        {heading}
+        <div className="rounded-xl border border-rose-200 bg-rose-50 p-8 text-center text-sm text-rose-600 shadow-sm dark:border-rose-500/50 dark:bg-rose-500/10 dark:text-rose-100">
+          Unable to load the selected models. Please return to the catalog and try again.
+        </div>
+      </div>
+    );
+  }
+
+  if (models.length < 2) {
+    return (
+      <div className="space-y-6">
+        {heading}
+        <div className="rounded-xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-500 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+          Select at least two models to see a detailed comparison.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {heading}
+      <ModelComparisonTable models={models as CatalogModel[]} onRemoveModel={handleRemoveModel} onClear={handleClear} />
+    </div>
+  );
+}

--- a/frontend/components/catalog/CompareModelsModal.tsx
+++ b/frontend/components/catalog/CompareModelsModal.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useModels, useModelFilterOptions } from "../../lib/hooks/useModels";
+import { ModelFilterValues } from "./ModelFilterPanel";
+import { defaultModelFilters, defaultCatalogSort, catalogSortOptions } from "../../lib/catalogFilters";
+import { Modal } from "../ui/Modal";
+import { Input } from "../ui/Input";
+import { Select } from "../ui/Select";
+import { Pagination } from "../ui/Pagination";
+import { Button } from "../ui/Button";
+
+interface CompareModelsModalProps {
+  open: boolean;
+  onClose: () => void;
+  selectedModelIds: number[];
+  onToggleModel: (modelId: number) => void;
+  onConfirm: () => void;
+  maxSelections?: number;
+}
+
+const priceModelOptions = [
+  { label: "All pricing", value: "" },
+  { label: "Per token", value: "token" },
+  { label: "Per call", value: "call" },
+  { label: "Tiered", value: "tiered" },
+  { label: "Free", value: "free" },
+  { label: "Unknown", value: "unknown" }
+];
+
+export function CompareModelsModal({
+  open,
+  onClose,
+  selectedModelIds,
+  onToggleModel,
+  onConfirm,
+  maxSelections = 5
+}: CompareModelsModalProps) {
+  const [filters, setFilters] = useState<ModelFilterValues>({ ...defaultModelFilters });
+  const [sort, setSort] = useState<string>(defaultCatalogSort);
+  const [page, setPage] = useState<number>(1);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const { data: filterOptions } = useModelFilterOptions();
+
+  const query = useModels({
+    search: filters.search,
+    vendorName: filters.vendorName,
+    priceModel: filters.priceModel,
+    capability: filters.capability,
+    license: filters.license,
+    categories: filters.category,
+    sort,
+    page
+  });
+
+  const models = useMemo(() => query.data?.items ?? [], [query.data]);
+  const totalResults = query.data?.total ?? 0;
+  const pageSize = query.data?.page_size ?? 20;
+  const totalPages = Math.max(1, Math.ceil(totalResults / pageSize));
+
+  useEffect(() => {
+    if (!open) {
+      setSelectionError(null);
+    }
+  }, [open]);
+
+  const updateFilters = <K extends keyof ModelFilterValues>(key: K, value: ModelFilterValues[K]) => {
+    setFilters((current) => ({
+      ...current,
+      [key]: value
+    }));
+    setPage(1);
+  };
+
+  const handleToggle = (modelId: number) => {
+    const alreadySelected = selectedModelIds.includes(modelId);
+    if (!alreadySelected && selectedModelIds.length >= maxSelections) {
+      setSelectionError(`You can select up to ${maxSelections} models.`);
+      return;
+    }
+    setSelectionError(null);
+    onToggleModel(modelId);
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+  };
+
+  const vendorOptions = useMemo(
+    () => [
+      { label: "All vendors", value: "" },
+      ...((filterOptions?.vendors ?? []).map((vendor) => ({ label: vendor, value: vendor })))
+    ],
+    [filterOptions?.vendors]
+  );
+
+  const capabilityOptions = useMemo(
+    () => [
+      { label: "All capabilities", value: "" },
+      ...((filterOptions?.capabilities ?? []).map((capability) => ({ label: capability, value: capability })))
+    ],
+    [filterOptions?.capabilities]
+  );
+
+  const licenseOptions = useMemo(
+    () => [
+      { label: "All licenses", value: "" },
+      ...((filterOptions?.licenses ?? []).map((license) => ({ label: license, value: license })))
+    ],
+    [filterOptions?.licenses]
+  );
+
+  const categoryOptions = useMemo(
+    () => [
+      { label: "All categories", value: "" },
+      ...((filterOptions?.categories ?? []).map((category) => ({ label: category, value: category })))
+    ],
+    [filterOptions?.categories]
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Select models to compare"
+      panelClassName="max-w-4xl"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <Input
+            label="Search"
+            placeholder="Model or vendor"
+            value={filters.search}
+            onChange={(event) => updateFilters("search", event.target.value)}
+          />
+          <Select
+            label="Vendor"
+            value={filters.vendorName}
+            onChange={(event) => updateFilters("vendorName", event.target.value)}
+            options={vendorOptions}
+          />
+          <Select
+            label="Capability"
+            value={filters.capability}
+            onChange={(event) => updateFilters("capability", event.target.value)}
+            options={capabilityOptions}
+          />
+          <Select
+            label="License"
+            value={filters.license}
+            onChange={(event) => updateFilters("license", event.target.value)}
+            options={licenseOptions}
+          />
+          <Select
+            label="Category"
+            value={filters.category}
+            onChange={(event) => updateFilters("category", event.target.value)}
+            options={categoryOptions}
+          />
+          <Select
+            label="Pricing model"
+            value={filters.priceModel}
+            onChange={(event) => updateFilters("priceModel", event.target.value)}
+            options={priceModelOptions}
+          />
+          <Select
+            label="Sort"
+            value={sort}
+            onChange={(event) => {
+              setSort(event.target.value);
+              setPage(1);
+            }}
+            options={catalogSortOptions}
+          />
+        </div>
+
+        <div className="flex items-center justify-between text-sm text-slate-600 dark:text-slate-300">
+          <span>
+            Selected {selectedModelIds.length} / {maxSelections}
+          </span>
+          {selectionError && <span className="text-rose-500 dark:text-rose-300">{selectionError}</span>}
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-slate-200 dark:border-slate-800">
+          {query.isLoading ? (
+            <div className="p-6 text-center text-sm text-slate-500 dark:text-slate-400">Loading models...</div>
+          ) : query.isError ? (
+            <div className="p-6 text-center text-sm text-rose-500 dark:text-rose-300">
+              Failed to load models. Please adjust filters or try again later.
+            </div>
+          ) : models.length === 0 ? (
+            <div className="p-6 text-center text-sm text-slate-500 dark:text-slate-400">
+              No models match the current filters.
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+              <thead className="bg-slate-50/70 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/50 dark:text-slate-400">
+                <tr>
+                  <th className="w-12 px-4 py-3">Select</th>
+                  <th className="w-1/3 px-4 py-3">Vendor</th>
+                  <th className="px-4 py-3">Model</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 text-sm text-slate-700 dark:divide-slate-800 dark:text-slate-200">
+                {models.map((model) => {
+                  const isChecked = selectedModelIds.includes(model.id);
+                  return (
+                    <tr
+                      key={model.id}
+                      className={[
+                        "cursor-pointer transition",
+                        isChecked ? "bg-primary/10 dark:bg-primary/20" : "hover:bg-slate-50 dark:hover:bg-slate-800/60"
+                      ].join(" ")}
+                      onClick={() => handleToggle(model.id)}
+                    >
+                      <td className="px-4 py-3">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                          checked={isChecked}
+                          onChange={(event) => {
+                            event.stopPropagation();
+                            handleToggle(model.id);
+                          }}
+                          aria-label={`Select ${model.model} for comparison`}
+                        />
+                      </td>
+                      <td className="px-4 py-3">{model.vendor?.name ?? "Unknown vendor"}</td>
+                      <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-100">{model.model}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex justify-center">
+            <Pagination currentPage={page} totalPages={totalPages} onPageChange={handlePageChange} />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            Tip: You can compare up to {maxSelections} models at once.
+          </div>
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={onConfirm}
+              disabled={selectedModelIds.length < 2}
+              className={selectedModelIds.length < 2 ? "opacity-60" : undefined}
+            >
+              Compare models
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/components/catalog/ModelList.tsx
+++ b/frontend/components/catalog/ModelList.tsx
@@ -34,8 +34,6 @@ export interface CatalogModel {
 
 interface ModelListProps {
   models: CatalogModel[];
-  selectedModelIds?: number[];
-  onToggleCompare?: (modelId: number) => void;
   onSelectCapability?: (capability: string) => void;
   onSelectLicense?: (license: string) => void;
 }
@@ -88,13 +86,7 @@ const getVendorImage = (model: CatalogModel): string | null => {
   return fromVendor ?? fromModel ?? null;
 };
 
-export function ModelList({
-  models,
-  selectedModelIds = [],
-  onToggleCompare,
-  onSelectCapability,
-  onSelectLicense
-}: ModelListProps) {
+export function ModelList({ models, onSelectCapability, onSelectLicense }: ModelListProps) {
   const [activeDescription, setActiveDescription] = useState<{ title: string; content: string } | null>(null);
 
   const markdownComponents: Components = {
@@ -153,9 +145,6 @@ export function ModelList({
         <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
           <thead className="bg-slate-50/80 dark:bg-slate-900/50">
             <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              <th scope="col" className="w-28 px-3 py-3">
-                Compare
-              </th>
               <th scope="col" className="w-32 px-3 py-3 text-center">
                 Vendor
               </th>
@@ -179,7 +168,6 @@ export function ModelList({
               const licenses = normalizeStringArray(model.license);
               const categories = normalizeStringArray(model.categories);
               const releaseDate = formatReleaseDate(model.release_date);
-              const isSelected = selectedModelIds.includes(model.id);
               const vendorName = model.vendor?.name ?? "Unknown vendor";
               const vendorImage = getVendorImage(model);
               const vendorInitial = vendorName.charAt(0).toUpperCase();
@@ -191,18 +179,6 @@ export function ModelList({
                   key={model.id}
                   className="transition hover:bg-slate-50/80 dark:hover:bg-slate-900/40"
                 >
-                  <td className="w-28 px-3 py-4 align-top">
-                    <label className="flex items-center justify-center">
-                      <span className="sr-only">{`Select ${model.model} for comparison`}</span>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-                        checked={isSelected}
-                        onChange={() => onToggleCompare?.(model.id)}
-                        aria-label={`Select ${model.model} for comparison`}
-                      />
-                    </label>
-                  </td>
                   <td className="w-32 px-3 py-4 align-top text-center">
                     <div className="flex flex-col items-center gap-2">
                       <span className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-slate-200 bg-white text-sm font-semibold text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">

--- a/frontend/components/ui/Modal.tsx
+++ b/frontend/components/ui/Modal.tsx
@@ -2,15 +2,17 @@
 
 import { Fragment, ReactNode, useEffect } from "react";
 import { Dialog, Transition } from "@headlessui/react";
+import classNames from "classnames";
 
 interface ModalProps {
   open: boolean;
   onClose: () => void;
   title?: ReactNode;
   children: ReactNode;
+  panelClassName?: string;
 }
 
-export function Modal({ open, onClose, title, children }: ModalProps) {
+export function Modal({ open, onClose, title, children, panelClassName }: ModalProps) {
   useEffect(() => {
     if (!open) return;
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -48,7 +50,12 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-xl border border-slate-200 bg-white p-6 text-left shadow-xl transition dark:border-slate-700 dark:bg-slate-900">
+              <Dialog.Panel
+                className={classNames(
+                  "w-full max-w-2xl transform overflow-hidden rounded-xl border border-slate-200 bg-white p-6 text-left shadow-xl transition dark:border-slate-700 dark:bg-slate-900",
+                  panelClassName
+                )}
+              >
                 {title && (
                   <Dialog.Title className="mb-4 text-lg font-semibold text-slate-800 dark:text-slate-100">
                     {title}

--- a/frontend/lib/catalogFilters.ts
+++ b/frontend/lib/catalogFilters.ts
@@ -1,0 +1,74 @@
+import { ModelFilterValues } from "../components/catalog/ModelFilterPanel";
+
+export const defaultModelFilters: ModelFilterValues = {
+  search: "",
+  vendorName: "",
+  priceModel: "",
+  priceCurrency: "",
+  capability: "",
+  license: "",
+  category: ""
+};
+
+export const catalogSortOptions: { label: string; value: string }[] = [
+  { label: "Release date (newest)", value: "release_desc" },
+  { label: "Release date (oldest)", value: "release_asc" },
+  { label: "Price (low to high)", value: "price_asc" },
+  { label: "Price (high to low)", value: "price_desc" },
+  { label: "Vendor (A-Z)", value: "vendor_asc" },
+  { label: "Model name (A-Z)", value: "model_asc" },
+  { label: "Model name (Z-A)", value: "model_desc" }
+];
+
+export const defaultCatalogSort = catalogSortOptions[0]?.value ?? "release_desc";
+
+export function filtersAreEqual(a: ModelFilterValues, b: ModelFilterValues) {
+  return (
+    a.search === b.search &&
+    a.vendorName === b.vendorName &&
+    a.priceModel === b.priceModel &&
+    a.priceCurrency === b.priceCurrency &&
+    a.capability === b.capability &&
+    a.license === b.license &&
+    a.category === b.category
+  );
+}
+
+export function parseCatalogSearchParams(params: URLSearchParams) {
+  const filters: ModelFilterValues = {
+    search: params.get("search") ?? "",
+    vendorName: params.get("vendor_name") ?? "",
+    priceModel: params.get("price_model") ?? "",
+    priceCurrency: params.get("price_currency") ?? "",
+    capability: params.get("capabilities") ?? "",
+    license: params.get("license") ?? "",
+    category: params.get("categories") ?? ""
+  };
+
+  const sort = params.get("sort") ?? defaultCatalogSort;
+  const page = Number.parseInt(params.get("page") ?? "1", 10);
+
+  return {
+    filters,
+    sort,
+    page: Number.isNaN(page) || page < 1 ? 1 : page
+  };
+}
+
+export function createCatalogSearchParams(
+  filters: ModelFilterValues,
+  sort: string,
+  page: number
+) {
+  const params = new URLSearchParams();
+  if (filters.search.trim()) params.set("search", filters.search.trim());
+  if (filters.vendorName) params.set("vendor_name", filters.vendorName);
+  if (filters.priceModel) params.set("price_model", filters.priceModel);
+  if (filters.priceCurrency) params.set("price_currency", filters.priceCurrency);
+  if (filters.capability) params.set("capabilities", filters.capability);
+  if (filters.license) params.set("license", filters.license);
+  if (filters.category) params.set("categories", filters.category);
+  if (sort && sort !== defaultCatalogSort) params.set("sort", sort);
+  if (page > 1) params.set("page", String(page));
+  return params;
+}


### PR DESCRIPTION
## Summary
- move catalog filters into URL parameters and add a compare toolbar with currency and pricing controls
- introduce a modal workflow to pick up to five models and navigate to a dedicated comparison page
- add supporting utilities, model fetching hooks, and layout adjustments for the new compare experience

## Testing
- not run (next lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e01a991dcc83218414c6f682c7bb3f